### PR TITLE
Topology update

### DIFF
--- a/backend/api/endpoints/switchesactive.py
+++ b/backend/api/endpoints/switchesactive.py
@@ -36,7 +36,6 @@ class SwitchesActive(Endpoint):
                 self.controller.switch_configs[switch_config["device_id"]].db_id = new_switch.id
             except IntegrityError:
                 self.db.session.rollback()
-                print("Entry in SwitchConfigs already exists")
                 existing_switch = SwitchConfigs.query.filter_by(name= new_switch.name, address = new_switch.address, device_id= new_switch.device_id).first()
                 self.controller.switch_configs[switch_config["device_id"]].db_id = existing_switch.id
         except Exception as e:
@@ -45,11 +44,10 @@ class SwitchesActive(Endpoint):
         
     def delete(self):
         parser = reqparse.RequestParser()
-        parser.add_argument('device_id', required = True, type=int)
+        parser.add_argument('device_id', required = False, type=int)
         args = parser.parse_args()
-        self.controller.deleteSwitchConnection(args['device_id'])
-        
-
-
-
-
+        if 'device_id' in args.keys() and args["device_id"]:
+            self.controller.deleteSwitchConnection(args['device_id'])
+        else:
+            self.controller.deleteAllSwitchConnections()
+                

--- a/backend/controller/controller.py
+++ b/backend/controller/controller.py
@@ -71,6 +71,14 @@ class Controller:
         self.switch_configs[switch_id].shutdown()
         # Remove reference
         del self.switch_configs[switch_id]
+        
+    def deleteAllSwitchConnections(self):
+        """Stops all active switch connections and removes their reference from internal storage.
+        """
+        for switch_id, s in self.switch_configs.items():
+            s.shutdown()
+        # Remove references
+        self.switch_configs = {}    
 
     def initialize(self, switch_id, p4_info_file, bmv2_file, keep_entries):
         """Initializes switch with given config.

--- a/frontend/src/Components/Mininet/Topology/TopologyRenderer.js
+++ b/frontend/src/Components/Mininet/Topology/TopologyRenderer.js
@@ -7,7 +7,7 @@ import './TopologyRenderer.css';
 export default function TopologyRenderer() {
 
     const svg_ref = useRef();
-    const { loadedTopology } = useTopology();
+    const { loadedTopology, getLoadedTopology, loadTopologyByName } = useTopology();
     const [layoutedTopology, setLayoutedTopology] = useState({});
 
     const icon_offset = {
@@ -22,8 +22,19 @@ export default function TopologyRenderer() {
     };
 
     function setupRender() {
+        getLoadedTopology();
+
         // Skip if no topology is loaded
-        if (loadedTopology.length < 1) { return }
+        if (loadedTopology.length < 1) {
+            // Clear all
+            // Get reference to SVG object
+            const svg = d3.select(svg_ref.current)
+                .attr('preserveAspectRatio', 'xMidYMid meet');
+
+            // Ensure that the object is empty
+            svg.selectAll("*").remove();
+            return;
+        }
         var topology = loadedTopology;
 
         // D3 requires an object with keys and values
@@ -117,9 +128,9 @@ export default function TopologyRenderer() {
                         .style("font-size", "0.4em")
                         .attr("x", node.x)
                         .attr("y", node.y - 8);
-                        // Set viewbox of SVG such that it scales correctly
+                    // Set viewbox of SVG such that it scales correctly
                     let bbox = svg.node().getBBox();
-                     svg.attr("viewBox", `${bbox.x} ${bbox.y} ${bbox.width} ${bbox.height}`);
+                    svg.attr("viewBox", `${bbox.x} ${bbox.y} ${bbox.width} ${bbox.height}`);
                 })
                 // Store topology layout to reload if necessary
                 // TODO: implement loading from stored
@@ -133,7 +144,7 @@ export default function TopologyRenderer() {
     // TODO: add loading animation
     return (
         <div id="TopologyContainer">
-            <svg id="TopologyRender" ref={svg_ref} style={{flexGrow: 1}}> </svg>
+            <svg id="TopologyRender" ref={svg_ref} style={{ flexGrow: 1 }}> </svg>
         </div>
     )
 }

--- a/frontend/src/Components/Mininet/Topology/TopologySelector.js
+++ b/frontend/src/Components/Mininet/Topology/TopologySelector.js
@@ -1,95 +1,98 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios'
 
-import { Button, FormControl, CircularProgress,TextField, Box, MenuItem, Checkbox, FormControlLabel} from '@mui/material';
+import { Button, FormControl, CircularProgress, TextField, Box, MenuItem, Checkbox, FormControlLabel, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 import { useSnackbar } from '../../../Contexts/SnackbarContext';
 import { useSwitch } from '../../../Contexts/SwitchContext';
 
 import { useTopology } from '../../../Contexts/TopologyContext';
 
-//import { handleSwitch } from '../SwitchConnections/SwitchDashboard/AddNewSwitch'
+import PublishIcon from '@mui/icons-material/Publish';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 
 export default function TopologySelector() {
     const { callSnackbar } = useSnackbar();
-    const { knownTopologies, setLoadedHosts, setCurrentTopologyName, currentTopologyName } = useTopology();
+    const { loadedTopology,knownTopologies, setLoadedHosts, currentTopologyName, getTopologies, getLoadedTopology, setCurrentTopologyName, setLoadedTopology } = useTopology();
 
-    const { switchesOnline, switches, getSwitches, deleteSwitch, getSwitchesOnline, setCurrentSwitchID, getHistorySwitches} = useSwitch();
+    const { switchesOnline, getSwitches, getSwitchesOnline, getHistorySwitches } = useSwitch();
 
     // Set selected topology state based on currently loaded or empty if none are loaded
     const [selectedTopology, setSelectedTopology] = useState(currentTopologyName);
     const [loading, setLoading] = useState(false);
     const [createSwitches, setCreateSwitches] = useState(true);
 
+    // Confirm dialog for topology clear
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+    // Start the emulation of a topology in the mininet container
     function loadTopology() {
 
-        console.log("Selected topology: " + selectedTopology);
-        // TODO do something with loading
         setLoading(true);
 
         // TODO dont hardcode netsim API
         axios
-        // Start up the topology in mininet
-        .post("http://127.0.0.1:5001/topology/load", {
-            topology_file: selectedTopology,
-        })
-        .then(res => {
-            setCurrentTopologyName(selectedTopology);
-            // Store list of loaded hosts
-            let hosts = res.data.hosts;
-            console.log("HOSTS",hosts);
-            setLoadedHosts(hosts);
-            getSwitchesOnline();
-            callSnackbar("success", "Updated topology to " + selectedTopology);
-
-            const switches_in_topology = Object.keys(res.data.switches);
-            // Disconnect switches and optionally connect switches from topology
-            let new_switches = [];
-            switchesOnline["switches_online"].map((s) => {
-                // Assert that the switches from online are contained in the selected topology
-                const newSwitchConfig = {
-                    name: s.name,
-                    address: "127.0.0.1:" + s.grpc_port,
-                    device_id: s.dev_id,
-                    proto_dump_file: s.name + "_proto.log"
-                }                
-                if (switches_in_topology.includes(s.name)){
-                    new_switches.push(newSwitchConfig);
-                    console.log("Create switch " + s.name + " " + s.grpc_port)
-                }
+            // Start up the topology in mininet
+            .post("http://127.0.0.1:5001/topology/load", {
+                topology_file: selectedTopology,
             })
+            .then(res => {
+                getLoadedTopology();
+                // Store list of loaded hosts
+                let hosts = res.data.hosts;
+                console.log("HOSTS", hosts);
+                setLoadedHosts(hosts);
+                getSwitchesOnline();
+                callSnackbar("success", "Updated topology to " + currentTopologyName);
 
-            
+                const switches_in_topology = Object.keys(res.data.switches);
+                // Disconnect switches and optionally connect switches from topology
+                let new_switches = [];
+                switchesOnline["switches_online"].forEach((s) => {
+                    // Assert that the switches from online are contained in the selected topology
+                    const newSwitchConfig = {
+                        name: s.name,
+                        address: "127.0.0.1:" + s.grpc_port,
+                        device_id: s.dev_id,
+                        proto_dump_file: s.name + "_proto.log"
+                    }
+                    if (switches_in_topology.includes(s.name)) {
+                        new_switches.push(newSwitchConfig);
+                        console.log("Create switch " + s.name + " " + s.grpc_port)
+                    }
+                })
 
-            if (new_switches.length !== switches_in_topology.length) {
-                let warning_msg = "Not all switches from the topology could be loaded. Try connecting them manually."
-                callSnackbar("warning", warning_msg);
-                console.log(warning_msg);
-            }    
 
-            // Disconnects all active switch connections and optionally connects the new ones from the topology
-            axios.post("/switches/from_topology", {
-                switch_configs: JSON.stringify(new_switches),
-                create_switches: createSwitches
-            }).then(res => {
-                getSwitches();
-                getHistorySwitches();
-                setLoading(false);
+
+                if (new_switches.length !== switches_in_topology.length) {
+                    let warning_msg = "Not all switches from the topology could be loaded. Try connecting them manually."
+                    callSnackbar("warning", warning_msg);
+                    console.log(warning_msg);
+                }
+
+                // Disconnects all active switch connections and optionally connects the new ones from the topology
+                axios.post("/switches/from_topology", {
+                    switch_configs: JSON.stringify(new_switches),
+                    create_switches: createSwitches
+                }).then(res => {
+                    getSwitches();
+                    getHistorySwitches();
+                    setLoading(false);
+                })
+                    .catch(err => {
+                        if (Object.keys(err).includes("response")) {
+                            callSnackbar("error", "There was an error while adding the switch: " + err.response.data + ". Try connecting it manually.");
+                        } else {
+                            callSnackbar("error", "There was an error while adding the switch: " + err + ". Try connecting it manually.");
+                        }
+                        console.log(err);
+                        setLoading(false);
+                    })
             })
             .catch(err => {
-                if (Object.keys(err).includes("response")) {
-                    callSnackbar("error", "There was an error while adding the switch: " + err.response.data + ". Try connecting it manually.");
-                } else {
-                    callSnackbar("error", "There was an error while adding the switch: " + err + ". Try connecting it manually.");
-                }
-                console.log(err);
                 setLoading(false);
-            })
-        })
-        .catch(err => {
-            setLoading(false);
-            console.log(err);
-            callSnackbar("error", "There was an error during loading a new topology! '" + err.message + "'" + " Check the log of the mininet docker container!");
-        });
+                console.log(err);
+                callSnackbar("error", "There was an error during loading a new topology! '" + err.message + "'" + " Check the log of the mininet docker container!");
+            });
 
     }
 
@@ -98,6 +101,54 @@ export default function TopologySelector() {
             setSelectedTopology(name);
         }
     }
+
+    const handleClearClick = () => {
+        setIsDialogOpen(true);
+    }
+
+    const handleClearClose = () => {
+        setIsDialogOpen(false);
+    };
+
+    const clearTopology = () => {
+        setLoading(true);
+        axios.delete("/switches/active", {headers: {accept: "application/json"}, data: {}})
+            .then((res) => {
+                // Destroy mininet topology
+                axios.delete("http://127.0.0.1:5001/topology/load", {headers: {accept: "application/json"}, data: {}})
+                    .then((res) => {
+                        // Update states
+                        getSwitches();
+                        getHistorySwitches();
+                        getSwitchesOnline();
+                        setCurrentTopologyName("");
+                        setLoadedTopology("");
+                        setLoadedHosts([]);
+                        handleClearClose();
+                        setLoading(false);
+                        callSnackbar("success", "Cleared topology");
+                    })
+                    .catch(err => {
+                        if (Object.keys(err).includes("response")) {
+                            callSnackbar("error", "There was an error while clearing the topology: " + err.response.data + ".");
+                        } else {
+                            callSnackbar("error", "There was an error while clearing the topology: " + err + ".");
+                        }
+                        console.log(err);
+                        setLoading(false);
+                    })
+            })
+            .catch(err => {
+                if (Object.keys(err).includes("response")) {
+                    callSnackbar("error", "There was an error while disconneting the switches: " + err.response.data + ".");
+                } else {
+                    callSnackbar("error", "There was an error while disconneting the switches: " + err + ".");
+                }
+                console.log(err);
+                setLoading(false);
+            })
+        console.log('Cleared topology.');
+    };
 
     return (
         <FormControl>
@@ -108,11 +159,12 @@ export default function TopologySelector() {
                     select
                     value={selectedTopology}
                     sx={{ flexGrow: 1, marginRight: "16px" }}
+                    onFocus={() => { getTopologies() }}
                     onChange={(event) => { changeTopology(event.target.value) }}>
                     {
                         knownTopologies.map(
                             (topologyName) => (
-                               <MenuItem key={topologyName} value={topologyName}>{topologyName}</MenuItem>
+                                <MenuItem key={topologyName} value={topologyName}>{topologyName}</MenuItem>
                             )
                         )
                     }
@@ -123,26 +175,57 @@ export default function TopologySelector() {
                             checked={createSwitches || ""}
                             onChange={(event) => setCreateSwitches(event.target.checked)}
                             color="primary"
-                            />
+                        />
                     }
                     label="Try to connect switches from topology"
                 />
                 {
                     // Show loading indicator if topology is loading,
                     // otherwise show load topology button
-                    loading ? 
-                    <CircularProgress />
-                    :
-                    <Button
-                    variant="contained"
-                    color='primary'
-                    type='submit'
-                    onClick={loadTopology}
-                    sx={{ marginLeft: 'auto' }}
-                    >Load Topology
-                    </Button>
+                    loading ?
+                        <CircularProgress />
+                        :
+                        <Button
+                            variant="contained"
+                            color='primary'
+                            type='submit'
+                            startIcon={<PublishIcon />}
+                            onClick={loadTopology}
+                            sx={{ marginLeft: 'auto' }}
+                        >Load Topology
+                        </Button>
                 }
-                
+                <Button
+                    variant="contained"
+                    type='submit'
+                    onClick={handleClearClick}
+                    startIcon={<DeleteForeverIcon />}
+                    sx={{ backgroundColor: '#800000', marginLeft: '10px', paddingLeft: '10px' }}
+                >Clear Topology
+                </Button>
+
+                <Dialog
+                    open={isDialogOpen}
+                    onClose={handleClearClose}
+                    aria-labelledby="alert-dialog-title"
+                    aria-describedby="alert-dialog-description"
+                >
+                    <DialogTitle id="alert-dialog-title">{"Confirm Action"}</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText id="alert-dialog-description">
+                            This will clear the topology in Mininet. All switches will be disconnected. Unsaved table entries will be lost. Are you sure you want to proceed?
+                        </DialogContentText>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={handleClearClose} color="primary">
+                            Cancel
+                        </Button>
+                        <Button onClick={clearTopology} color="primary" autoFocus>
+                            Yes!
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+
             </Box>
         </FormControl>
     )

--- a/frontend/src/Contexts/TopologyContext.js
+++ b/frontend/src/Contexts/TopologyContext.js
@@ -13,42 +13,63 @@ export function TopologyProvider({ children }) {
     // Get reference for calls to Snackbar Info Banner
     const { callSnackbar } = useSnackbar();
 
-    // State thas saves list of known Topologies
+    // State that saves list of known Topologies
     const [knownTopologies, setKnownTopologies] = useState([]);
     const [loadedTopology, setLoadedTopology] = useState("");
     const [loadedHosts, setLoadedHosts] = useState([]);
 
-    // Topology that is currently loaded
-    // Will try to fetch this from local storage, is set to null if none is stored
-    const [currentTopologyName, setCurrentTopologyName] = useState(() => {
-        const topologyName = localStorage.getItem("currentTopologyName");
-        return (topologyName === "null") ? null : topologyName;
-    });
+    // Topology that is currently loaded in Mininet
+    const [currentTopologyName, setCurrentTopologyName] = useState("");
 
     // Request topology data from backend and store state
-    function loadTopologyByName(name) {
+    function loadTopologyByName() {
+        if (currentTopologyName === "") {
+            setLoadedTopology("");
+            setLoadedHosts([]);
+            return;
+        }
+
+        console.log("Loading topology....")
+
         axios
             .get("/topologies", {
                 params: {
-                    "name": name
+                    "name": currentTopologyName
                 }
             })
             .then(res => {
-                // Store name for new topology
-                setCurrentTopologyName(name);
                 // Store topology Data
-                setLoadedTopology(res.data[name]);
+                setLoadedTopology(res.data[currentTopologyName]);
+                setLoadedHosts(res.data[currentTopologyName]["hosts"])
             })
             .catch(err => {
-                callSnackbar("errpr","Failed to load topology with name: "+name)
+                callSnackbar("error", "Failed to load topology with name: " + currentTopologyName)
+                console.log(err);
+            });
+        console.log(loadedTopology);
+    }
+
+    // Get topology that is currently loaded in Mininet and store it in state
+    function getLoadedTopology() {
+        axios
+            .get("http://127.0.0.1:5001/topology/get", {
+            })
+            .then(res => {
+                // Store name for new topology
+                if (res.data["file_name"] === null) {
+                    setCurrentTopologyName("");
+                    setLoadedTopology("");
+                } else {
+                    setCurrentTopologyName(res.data["file_name"]);
+                }
+            })
+            .catch(err => {
+                callSnackbar("error", "Failed to get active topology")
                 console.log(err);
             });
     }
 
-    // Store loaded topology name on use
-    useEffect(() => {
-        localStorage.setItem("currentTopologyName", currentTopologyName);
-    }, [currentTopologyName])
+
 
     function getTopologies() {
         axios
@@ -56,9 +77,9 @@ export function TopologyProvider({ children }) {
             .then(res => {
                 setKnownTopologies(res.data.topologies);
                 // Also load topology info if name is already configued
-                const topologyName = localStorage.getItem("currentTopologyName");
+                //const topologyName = localStorage.getItem("currentTopologyName");
                 // Load topology only if name is set
-                if ( !(topologyName === "null")) {loadTopologyByName(topologyName);} 
+                //if ( !(topologyName === "null")) {loadTopologyByName(topologyName);} 
             })
             .catch(err => {
                 console.log(err);
@@ -67,9 +88,11 @@ export function TopologyProvider({ children }) {
 
     // When used, first get available topologies
     useEffect(getTopologies, []);
+    useEffect(getLoadedTopology, [])
+    useEffect(loadTopologyByName, [currentTopologyName]);
 
     return (
-        <TopologyContext.Provider value={{knownTopologies, getTopologies, currentTopologyName, setCurrentTopologyName,loadTopologyByName,loadedTopology,loadedHosts,setLoadedHosts}}>
+        <TopologyContext.Provider value={{ knownTopologies, getTopologies, currentTopologyName, setCurrentTopologyName, loadTopologyByName, getLoadedTopology, loadedTopology, loadedHosts, setLoadedHosts, setLoadedTopology }}>
             {children}
         </TopologyContext.Provider>
     )

--- a/netsim/api/__init__.py
+++ b/netsim/api/__init__.py
@@ -92,7 +92,7 @@ class WebsocketManager:
 
         # Stop CLIs that are still running
         for name, cli in self.clis.items():
-            cli.stop()
+            cli.node.stop()
 
         # Delete old dictionary
         self.clis = {}

--- a/netsim/api/endpoints/load_topology.py
+++ b/netsim/api/endpoints/load_topology.py
@@ -11,7 +11,6 @@ class LoadTopology(Endpoint):
         args = parser.parse_args()
                 
         try:
-            # TODO make this async so that frontend does not block?
             self.netsim.topo_file = args.topology_file
             self.netsim.run()
             
@@ -32,6 +31,7 @@ class LoadTopology(Endpoint):
     def delete(self):
         try:
             self.netsim.destroy_topology()
+            self.netsim.topo_file = None
             topo = {
                 "hosts": self.netsim.hosts,
                 "switches": self.netsim.switches,

--- a/netsim/api/netsim/netsim.py
+++ b/netsim/api/netsim/netsim.py
@@ -194,16 +194,21 @@ class MininetRunner:
         self.net = None
         P4Switch.device_id = 0
         P4RuntimeSwitch.next_grpc_port = 50051
+        
+        self.hosts = []
+        self.switches = {}
+        self.links = []
 
     def run(self):
         """ Sets up the mininet instance, programs the switches,
             and starts the mininet CLI. This is the main method to run after
             initializing the object.
         """
-        self.parse_topology_file()
-        
         # Clean up existing topologies
-        self.destroy_topology()   
+        self.destroy_topology()  
+        
+        self.parse_topology_file()
+ 
         self.logger("Started topology!")
         
         # Initialize mininet with the topology specified by the config
@@ -361,30 +366,4 @@ class MininetRunner:
             print('')
 
         CLI(self.net)
-
-
-# TODO remove
-def get_args():
-    cwd = os.getcwd()
-    default_logs = os.path.join(cwd, 'logs')
-    default_pcaps = os.path.join(cwd, 'pcaps')
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-q', '--quiet', help='Suppress log messages.',
-                        action='store_true', required=False, default=False)
-    parser.add_argument('-t', '--topo', help='Path to topology json',
-                        type=str, required=False, default='./topology.json')
-    parser.add_argument('-l', '--log-dir', type=str, required=False, default=default_logs)
-    parser.add_argument('-p', '--pcap-dir', type=str, required=False, default=default_pcaps)
-    return parser.parse_args()
-
-
-# TODO remove
-if __name__ == '__main__':
-    # from mininet.log import setLogLevel
-    # setLogLevel("info")
-
-    args = get_args()
-    mininet = MininetRunner(args.topo, args.log_dir, args.pcap_dir, args.quiet)
-
-    mininet.run()
-
+        


### PR DESCRIPTION
- Fix crash in topology load for terminals
- Remove active topology from localStorage, use the Mininet API endpoint instead
- Added a button to clear the loaded topology and disconnect all switches